### PR TITLE
Fix ValueError: Images of type float must be between -1 and 1

### DIFF
--- a/imaris_ims_file_reader/ims.py
+++ b/imaris_ims_file_reader/ims.py
@@ -434,6 +434,7 @@ class ims:
         rescaleFactor = tuple([round(x/y,5) for x,y in zip(workingVolumeResolution,output_resolution)])
         print('Rescale Factor = {}'.format(rescaleFactor))
 
+        workingVolume = img_as_float32(workingVolume)
         workingVolume = rescale(workingVolume, rescaleFactor, anti_aliasing=anti_aliasing)
 
         return self.dtypeImgConvert(workingVolume)


### PR DESCRIPTION
ValueError                                
Traceback (most recent call last)
/tmp/ipykernel_9760/2798298318.py in <module>
----> 1 brain1_res10 = latest_data_ims.get_Volume_At_Specific_Resolution(output_resolution=(10, 10, 10))

~/bio/imaris_ims_file_reader/imaris_ims_file_reader/ims.py in get_Volume_At_Specific_Resolution(self, output_resolution, time_point, channel, anti_aliasing)
    438         workingVolume = rescale(workingVolume, rescaleFactor, mode="constant", preserve_range=True, anti_aliasing=anti_aliasing)
    439 
--> 440         return self.dtypeImgConvert(workingVolume)
    441 
    442     def get_Resolution_Level(self, resolution_level, time_point=0, channel=0):

~/bio/imaris_ims_file_reader/imaris_ims_file_reader/ims.py in dtypeImgConvert(self, image)
    336             return img_as_float32(image)
    337         elif self.dtype == np.uint16:
--> 338             return img_as_uint(image)
    339         elif self.dtype == np.uint8:
    340             return img_as_ubyte(image)

~/.local/lib/python3.8/site-packages/skimage/util/dtype.py in img_as_uint(image, force_copy)
    490 
    491     """
--> 492     return _convert(image, np.uint16, force_copy)
    493 
    494 

~/.local/lib/python3.8/site-packages/skimage/util/dtype.py in _convert(image, dtype, force_copy, uniform)
    281 
    282         if np.min(image) < -1.0 or np.max(image) > 1.0:
--> 283             raise ValueError("Images of type float must be between -1 and 1.")
    284         # floating point -> integer
    285         # use float type that can represent output integer type

ValueError: Images of type float must be between -1 and 1.